### PR TITLE
ユーザー検索のインクリメンタルサーチ化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rspec-rails', '~> 3.5'
   gem 'rails-controller-testing'
-  gem 'factory_girl_rails', '~> 4.0'
+  gem 'factory_bot_rails'
   gem 'faker'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,10 +78,10 @@ GEM
       html2haml
     erubis (2.7.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
     faker (1.9.1)
       i18n (>= 0.7)
@@ -257,7 +257,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   devise
   erb2haml
-  factory_girl_rails (~> 4.0)
+  factory_bot_rails
   faker
   font-awesome-rails
   haml-rails

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -18,22 +18,35 @@ $(function() {
 
   $('#user-search-field').on('keyup', function() {
     var input = $('#user-search-field').val();
-    $.ajax({
-      type: 'GET',
-      url: '/users',
-      data: { keyword: input },
-      dataType: 'json'
-    })
-    .done(function(users) {
-      $('#user-search-result').empty();
-      users.forEach(function(user){
-        var html = appendUser(user);
-        $('#user-search-result').append(html);
-      });
-   	})
-    .fail(function(){
-      alert('ユーザーの検索に失敗しました');
-    })
+    if(input.length > 0){
+      $.ajax({
+        type: 'GET',
+        url: '/users',
+        data: { keyword: input },
+        dataType: 'json'
+      })
+      .done(function(users) {
+        $('#user-search-result').empty();
+        users.forEach(function(user){
+          var html = appendUser(user);
+          $('#user-search-result').append(html);
+        });
+     	})
+      .fail(function(){
+        alert('ユーザーの検索に失敗しました');
+      })
+    }
+    else{
+      $.ajax({
+        type: 'GET',
+        url: '/users',
+        data: { keyword: input },
+        dataType: 'json'
+      })
+      .done(function(users) {
+        $('#user-search-result').empty();
+      })
+    }
   });
 
   $('#user-search-result').on('click','.chat-group-user__btn--add', function() {

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -1,0 +1,66 @@
+$(function() {
+	function appendUser(user){
+    var html = `<div class="chat-group-user clearfix">
+                  <p class="chat-group-user__name">${user.user_name}</p>
+                  <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.user_id}" data-user-name="${user.user_name}">追加</a>
+                </div>`
+    return html;
+  }
+
+  function removeUser(name,id){
+    var html = `<div class='chat-group-user clearfix js-chat-member'>
+                  <input name='group[user_ids][]' type='hidden' value='${id}'>
+                  <p class='chat-group-user__name'>${name}</p>
+                  <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
+                </div>`
+    return  html;
+  }
+
+  $('#user-search-field').on('keyup', function() {
+    var input = $('#user-search-field').val();
+    $.ajax({
+      type: 'GET',
+      url: '/users',
+      data: { keyword: input },
+      dataType: 'json'
+    })
+    .done(function(users) {
+      $('#user-search-result').empty();
+      users.forEach(function(user){
+        var html = appendUser(user);
+        $('#user-search-result').append(html);
+      });
+   	})
+    .fail(function(){
+      alert('ユーザーの検索に失敗しました');
+    })
+  });
+
+  $('#user-search-result').on('click','.chat-group-user__btn--add', function() {
+    var id = $(this).data('user-id');
+    var name  = $(this).data('user-name');
+    var html = removeUser(name,id);
+    $('#chat-group-users').append(html)
+    $(this).parent().empty()
+  });
+
+  $('#chat-group-users').on('click','.js-remove-btn', function() {
+    $(this).parent().empty()
+  });
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+});

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -47,20 +47,4 @@ $(function() {
   $('#chat-group-users').on('click','.js-remove-btn', function() {
     $(this).parent().empty()
   });
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 });

--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -47,4 +47,5 @@ $(function() {
   $('#chat-group-users').on('click','.js-remove-btn', function() {
     $(this).parent().empty()
   });
+
 });

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user.id)
+    @users = User.search_for_group(params, current_user.id)
     respond_to do |format|
       format.html
       format.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,13 @@
 class UsersController < ApplicationController
 
+  def index
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%")
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
 	def edit
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ApplicationRecord
   has_many :group_users
   has_many :groups, through: :group_users
   has_many :messages
+
+  def self.search_for_group(params, current)
+  	where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current)
+  end
 end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -24,7 +24,7 @@
     .chat-group-form__field--right
       #chat-group-users
         .chat-group-user.clearfix
-          = hidden_field_tag :user_ids, current_user.id, name: "chat_group[user_ids][]"
+          = hidden_field_tag :user_ids, current_user.id, name: "group[user_ids][]"
           %p.chat-group-user__name
             = current_user.name
 

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -9,33 +9,26 @@
     .chat-group-form__field--left
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
-      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', name: "keyword", placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-    /
-      <div class='chat-group-form__field--left'>
-      <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-      </div>
-      <div class='chat-group-form__field--right'>
-      <div class='chat-group-form__search clearfix'>
-      <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-      </div>
-      <div id='user-search-result'></div>
-      </div>
+    .chat-group-form__field--left
+      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+    .chat-group-form__field--right
+      .chat-group-form__search.clearfix
+      %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      #user-search-result
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバー"} チャットメンバー
+      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-      /
-        <div id='chat-group-users'>
-        <div class='chat-group-user clearfix' id='chat-group-user-22'>
-        <input name='chat_group[user_ids][]' type='hidden' value='22'>
-        <p class='chat-group-user__name'>seo_kyohei</p>
-        </div>
-        </div>
+      #chat-group-users
+        .chat-group-user.clearfix
+          %input{:name => "chat_group[user_ids][]", :type => "hidden", :value => current_user.id}/
+          %p.chat-group-user__name
+            = current_user.name
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,7 +11,6 @@
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat__group_name chat-group-form__input', name: "keyword", placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
     .chat-group-form__field--left
       %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
     .chat-group-form__field--right

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -9,22 +9,22 @@
     .chat-group-form__field--left
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
-      = f.text_field :name, class: 'chat__group_name chat-group-form__input', name: "keyword", placeholder: 'グループ名を入力してください'
+      = f.text_field :name, class: 'chat__group_name chat-group-form__input', placeholder: 'グループ名を入力してください'
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{:for => "chat_group_チャットメンバーを追加"} チャットメンバーを追加
+      = label_tag :search, 'チャットメンバーを追加', class: 'chat-group-form__label', for: "user-search-field"
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-      %input#user-search-field.chat-group-form__input{:placeholder => "追加したいユーザー名を入力してください", :type => "text"}/
+      = text_field_tag :search, "", class: 'chat-group-form__input', id: "user-search-field", placeholder: "追加したいユーザー名を入力してください"
       #user-search-result
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
-      %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
+      = label_tag :user_ids, 'チャットメンバー', class: 'chat-group-form__label', for: "user_ids"
     .chat-group-form__field--right
       #chat-group-users
         .chat-group-user.clearfix
-          %input{:name => "chat_group[user_ids][]", :type => "hidden", :value => current_user.id}/
+          = hidden_field_tag :user_ids, current_user.id, name: "chat_group[user_ids][]"
           %p.chat-group-user__name
             = current_user.name
 

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+	json.user_id   user.id
+	json.user_name user.name
+end

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,4 +1,6 @@
 json.array! @users do |user|
-	json.user_id   user.id
-	json.user_name user.name
+
+  json.user_id   user.id
+  json.user_name user.name
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
-  root	'groups#index'
-  resources :users, only: [:edit, :update]
+  root 'groups#index'
+  resources :users, only: [:edit, :update,:index]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :group do
     name Faker::Team.name
   end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,8 +1,8 @@
-FactoryGirl.define do
-  factory :message do
-    content Faker::Lorem.sentence
-    image File.open("#{Rails.root}/public/images/no_image.jpg")
-    user
-    group
-  end
-end
+# FactoryGirl.define do
+#   factory :message do
+#     content Faker::Lorem.sentence
+#     image File.open("#{Rails.root}/public/images/no_image.jpg")
+#     user
+#     group
+#   end
+# end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,8 +1,8 @@
-# FactoryGirl.define do
-#   factory :message do
-#     content Faker::Lorem.sentence
-#     image File.open("#{Rails.root}/public/images/no_image.jpg")
-#     user
-#     group
-#   end
-# end
+FactoryBot.define do
+  factory :message do
+    content Faker::Lorem.sentence
+    image File.open("#{Rails.root}/public/images/スクリーンショット 2018-08-20 16.02.21.png")
+    user
+    group
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     password = Faker::Internet.password(8)
     name Faker::Name.last_name

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -34,7 +34,7 @@ RSpec.configure do |config|
   Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include ControllerMacros, type: :controller
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
 


### PR DESCRIPTION
FactoryGirlはターミナルを動かす際にエラーが出たので、コメントアウトした。

ルーティングでusersコントローラーのindexアクションを動かす設定をした。

Jbuilderでは条件に当てはまる全ユーザーを配列として、データを渡すために、arrayを使った。

_form.html.hamlではグループ編集画面でチャットメンバーにcurrentuserが常に表示されるようにした。

index.jsではチャットメンバーを追加するフォームに文字を打ち込むたびに、曖昧検索をかけ、該当するユーザーが表示されるようにして、そのhtmlをappendUserに定義した。

追加されたユーザーはチャットーメンバーの欄、カレントユーザーの下に追加されるように設定した。
また、ユーザーを追加するボタンを押すとそのユーザーは追加欄からは消えるようにした。

削除ボタンを押すとチャットメンバーの欄からは消えるようにした。